### PR TITLE
chore: Promote unstable to rc

### DIFF
--- a/stencil.lock
+++ b/stencil.lock
@@ -9,9 +9,6 @@ modules:
     - name: github.com/getoutreach/stencil-circleci
       url: https://github.com/getoutreach/stencil-circleci
       version: v1.6.1
-    - name: github.com/getoutreach/stencil-discovery
-      url: https://github.com/getoutreach/stencil-discovery
-      version: v1.3.3
     - name: github.com/getoutreach/stencil-golang
       url: https://github.com/getoutreach/stencil-golang
       version: v1.6.2


### PR DESCRIPTION
Promote unstable to rc, created by `dt release promote`

**DO NOT MERGE**